### PR TITLE
Add baseurl to all URLs in templates and redirects.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,5 @@
 RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule . /index.php [L]
+# CHECKME: is index.php in reference to the current http path or to this htaccess file?
+RewriteRule . index.php [L]

--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,5 @@
 RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-# CHECKME: is index.php in reference to the current http path or to this htaccess file?
+# A "." rule matches anything, from "/" to a longer path.
 RewriteRule . index.php [L]

--- a/index.php
+++ b/index.php
@@ -16,6 +16,13 @@ $app->register(new Silex\Provider\TwigServiceProvider(), array(
 // enable Silex debugging
 $app['debug'] = true;
 
+// set the basurl for all templates
+$app->before(function () use ($app)
+{
+    // maybe a misnomer - getBaseUrl() seems to get a base *path*
+    $app["twig"]->addGlobal('baseurl', $app['request']->getBaseUrl());
+});
+
 // root route
 $app->get('/', function() use ($app) {
     $gateways = array_map(function($name) {
@@ -51,7 +58,7 @@ $app->post('/gateways/{name}', function($name) use ($app) {
     // redirect back to gateway settings page
     $app['session']->getFlashBag()->add('success', 'Gateway settings updated!');
 
-    return $app->redirect($app['request']->getPathInfo());
+    return $app->redirect($app['request']->getBaseUrl() . $app['request']->getPathInfo());
 });
 
 // create gateway authorize

--- a/views/gateway.twig
+++ b/views/gateway.twig
@@ -30,11 +30,11 @@ $response = $gateway->initialize($params);</pre>
     <p>Click on a method to generate a test request.</p>
     <ul>
         {% if gateway.supportsAuthorize() %}
-            <li><a href="/gateways/{{gateway.shortName}}/authorize">authorize()</a></li>
+            <li><a href="{{ baseurl }}/gateways/{{gateway.shortName}}/authorize">authorize()</a></li>
         {% endif %}
-        <li><a href="/gateways/{{gateway.shortName}}/purchase">purchase()</a></li>
+        <li><a href="{{ baseurl }}/gateways/{{gateway.shortName}}/purchase">purchase()</a></li>
         {% if gateway.supportsCapture() %}
-            <li><a href="/gateways/{{gateway.shortName}}/capture">capture()</a></li>
+            <li><a href="{{ baseurl }}/gateways/{{gateway.shortName}}/capture">capture()</a></li>
         {% endif %}
         {% if gateway.supportsRefund() %}
             <li>refund()</li>
@@ -43,13 +43,13 @@ $response = $gateway->initialize($params);</pre>
             <li>void()</li>
         {% endif %}
         {% if gateway.supportsCreateCard() %}
-            <li><a href="/gateways/{{gateway.shortName}}/create-card">createCard()</a></li>
+            <li><a href="{{ baseurl }}/gateways/{{gateway.shortName}}/create-card">createCard()</a></li>
         {% endif %}
         {% if gateway.supportsUpdateCard() %}
-            <li><a href="/gateways/{{gateway.shortName}}/update-card">updateCard()</a></li>
+            <li><a href="{{ baseurl }}/gateways/{{gateway.shortName}}/update-card">updateCard()</a></li>
         {% endif %}
         {% if gateway.supportsDeleteCard() %}
-            <li><a href="/gateways/{{gateway.shortName}}/delete-card">deleteCard()</a></li>
+            <li><a href="{{ baseurl }}/gateways/{{gateway.shortName}}/delete-card">deleteCard()</a></li>
         {% endif %}
     </ul>
 

--- a/views/index.twig
+++ b/views/index.twig
@@ -6,7 +6,7 @@
 
     <ul>
         {% for gateway in gateways %}
-            <li><a href="/gateways/{{ gateway.shortName }}">{{ gateway.name }}</a></li>
+            <li><a href="{{ baseurl }}/gateways/{{ gateway.shortName }}">{{ gateway.name }}</a></li>
         {% endfor %}
     </ul>
 {% endblock %}

--- a/views/layout.twig
+++ b/views/layout.twig
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>{{ title }}</title>
-    <link href="/assets/bootstrap.css" rel="stylesheet">
+    <link href="{{ baseurl }}/assets/bootstrap.css" rel="stylesheet">
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
https://github.com/thephpleague/omnipay-example/issues/3

Here you go - take it or leave it :-)

I personally find the example application very useful when developing on a gateway, and also as the first point of call when trying to understand OmniPay for the first time. There are so many different platforms to develop on these days, that it helps to have this flexibility. I tend to have so many things on the go at once, that it is easier to plonk a bunch of projects on one server than to have a gazzillion servers brought up all over the place. But YMMV, naturally :-)

I've tested this in a sub-directory and also the root folder of a domain, with mod_php 5.4, and it works for me, though there could always be some path I've not taken into account.