### PR TITLE
Added a script to find/add missing Gateways in the vendor/omnipay/common/composer.json file

### DIFF
--- a/updategateways.sh
+++ b/updategateways.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Scans for OmniPay gateways that are missing from the common/composer.json GateWay listing
+# and optionally inserts any missing ones
+errors=0; 
+base="$(readlink -f "$(dirname "$0")")";
+cd "$base";
+if [ ! -e vendor ]; then
+	echo "run 'composer up' before you run this";
+	exit;
+fi;
+cd "$base/vendor"
+prefix="$PWD";
+for name in $(for file in $(grep -l "^class .* extends " */*/src/*Gateway.php); do 
+    rest="$(grep '^class .*Gateway extends' $file | cut -d" " -f2 | sed s#"Gateway$"#""#g)";  
+    name="$(grep '^namespace' $file | head -n 1 | cut -d\\ -f2 | cut -d\; -f1)" ; 
+    if [ "$rest" != "" ]; then
+        name="${name}_${rest}"; 
+    fi; 
+    echo $name; 
+done | sort ); do  
+f="$(grep "$name" $prefix/omnipay/common/composer.json)"; 
+if [ "$f" = "" ]; then 
+    echo "$name not present in omnipay/common/composer.json" ;
+    errors=$(($errors + 1)); 
+    if [ "$FIX" = "1" ]; then 
+        sed s#"^\( *\)\(\"gateways\": \[\)"#"\1\2\n\1    \"$name\","#g -i $prefix/omnipay/common/composer.json; 
+    fi; 
+fi;  
+done; 
+if [ $errors -gt 0 ]; then 
+    if [ "$FIX" != "1" ]; then
+        echo -e "$errors Errors\nset environment variable FIX=1 and call again to add the missing gateways"; 
+    else 
+        echo "Added $errors new Gateways";
+    fi;
+fi


### PR DESCRIPTION
(not sure if this should be sent to omnipay-common or omnipay-example, so sending to both)

It was written while playing with omnipay-example and expects to be in some sort of dir/omnipay/common type directory with other omnipay gateways
installed in dir/*/* for example   dir/omnipay/paypal.

It parses the various vendor/*/*/src/*Gateway.php files looking at the namespace and class name to determin the proper gateway name and searchs
if its already added to the common/composer.json file

Most people should be fine just running the script without worrying about changing anything

Calling it by itself will display a list of gateways missing (if any)
 - example #1:   ./updategateways.sh
Calling it by first setting the environment variable FIX=1 will insert the missing gateways into the common/composer.json file
 - example #2:   export FIX=1; ./updategateways.sh
 - example #3:   FIX=1 ./updategateways.sh

Runing the script found these to add:
* AuthorizeNet_DPM
* Buckaroo_CreditCard
* Eway_Direct
* Eway_RapidDirect
* Eway_RapidShared
* PayPal_Rest