### PR TITLE
Ensure that the client IP is always a valid IPv4 address

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,8 +17,7 @@ $app->register(new Silex\Provider\TwigServiceProvider(), array(
 $app['debug'] = true;
 
 // set the basurl for all templates
-$app->before(function () use ($app)
-{
+$app->before(function () use ($app) {
     // maybe a misnomer - getBaseUrl() seems to get a base *path*
     $app["twig"]->addGlobal('baseurl', $app['request']->getBaseUrl());
     // If we have an invalid IP, pop in localhost
@@ -30,8 +29,8 @@ $app->before(function () use ($app)
 });
 
 // root route
-$app->get('/', function() use ($app) {
-    $gateways = array_map(function($name) {
+$app->get('/', function () use ($app) {
+    $gateways = array_map(function ($name) {
         return Omnipay::create($name);
     }, Omnipay::find());
 
@@ -41,7 +40,7 @@ $app->get('/', function() use ($app) {
 });
 
 // gateway settings
-$app->get('/gateways/{name}', function($name) use ($app) {
+$app->get('/gateways/{name}', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -53,7 +52,7 @@ $app->get('/gateways/{name}', function($name) use ($app) {
 });
 
 // save gateway settings
-$app->post('/gateways/{name}', function($name) use ($app) {
+$app->post('/gateways/{name}', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['request']->get('gateway'));
@@ -68,7 +67,7 @@ $app->post('/gateways/{name}', function($name) use ($app) {
 });
 
 // create gateway authorize
-$app->get('/gateways/{name}/authorize', function($name) use ($app) {
+$app->get('/gateways/{name}/authorize', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -87,7 +86,7 @@ $app->get('/gateways/{name}/authorize', function($name) use ($app) {
 });
 
 // submit gateway authorize
-$app->post('/gateways/{name}/authorize', function($name) use ($app) {
+$app->post('/gateways/{name}/authorize', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -111,7 +110,7 @@ $app->post('/gateways/{name}/authorize', function($name) use ($app) {
 });
 
 // create gateway completeAuthorize
-$app->get('/gateways/{name}/completeAuthorize', function($name) use ($app) {
+$app->get('/gateways/{name}/completeAuthorize', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -126,7 +125,7 @@ $app->get('/gateways/{name}/completeAuthorize', function($name) use ($app) {
 });
 
 // create gateway capture
-$app->get('/gateways/{name}/capture', function($name) use ($app) {
+$app->get('/gateways/{name}/capture', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -141,7 +140,7 @@ $app->get('/gateways/{name}/capture', function($name) use ($app) {
 });
 
 // submit gateway capture
-$app->post('/gateways/{name}/capture', function($name) use ($app) {
+$app->post('/gateways/{name}/capture', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -162,7 +161,7 @@ $app->post('/gateways/{name}/capture', function($name) use ($app) {
 });
 
 // create gateway purchase
-$app->get('/gateways/{name}/purchase', function($name) use ($app) {
+$app->get('/gateways/{name}/purchase', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -181,7 +180,7 @@ $app->get('/gateways/{name}/purchase', function($name) use ($app) {
 });
 
 // submit gateway purchase
-$app->post('/gateways/{name}/purchase', function($name) use ($app) {
+$app->post('/gateways/{name}/purchase', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -206,7 +205,7 @@ $app->post('/gateways/{name}/purchase', function($name) use ($app) {
 
 // gateway purchase return
 // this won't work for gateways which require an internet-accessible URL (yet)
-$app->match('/gateways/{name}/completePurchase', function($name) use ($app) {
+$app->match('/gateways/{name}/completePurchase', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -224,7 +223,7 @@ $app->match('/gateways/{name}/completePurchase', function($name) use ($app) {
 });
 
 // create gateway create Credit Card
-$app->get('/gateways/{name}/create-card', function($name) use ($app) {
+$app->get('/gateways/{name}/create-card', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -241,7 +240,7 @@ $app->get('/gateways/{name}/create-card', function($name) use ($app) {
 });
 
 // submit gateway create Credit Card
-$app->post('/gateways/{name}/create-card', function($name) use ($app) {
+$app->post('/gateways/{name}/create-card', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -265,7 +264,7 @@ $app->post('/gateways/{name}/create-card', function($name) use ($app) {
 });
 
 // create gateway update Credit Card
-$app->get('/gateways/{name}/update-card', function($name) use ($app) {
+$app->get('/gateways/{name}/update-card', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -282,7 +281,7 @@ $app->get('/gateways/{name}/update-card', function($name) use ($app) {
 });
 
 // submit gateway update Credit Card
-$app->post('/gateways/{name}/update-card', function($name) use ($app) {
+$app->post('/gateways/{name}/update-card', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -306,7 +305,7 @@ $app->post('/gateways/{name}/update-card', function($name) use ($app) {
 });
 
 // create gateway delete Credit Card
-$app->get('/gateways/{name}/delete-card', function($name) use ($app) {
+$app->get('/gateways/{name}/delete-card', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));
@@ -321,7 +320,7 @@ $app->get('/gateways/{name}/delete-card', function($name) use ($app) {
 });
 
 // submit gateway delete Credit Card
-$app->post('/gateways/{name}/delete-card', function($name) use ($app) {
+$app->post('/gateways/{name}/delete-card', function ($name) use ($app) {
     $gateway = Omnipay::create($name);
     $sessionVar = 'omnipay.'.$gateway->getShortName();
     $gateway->initialize((array) $app['session']->get($sessionVar));

--- a/index.php
+++ b/index.php
@@ -21,6 +21,12 @@ $app->before(function () use ($app)
 {
     // maybe a misnomer - getBaseUrl() seems to get a base *path*
     $app["twig"]->addGlobal('baseurl', $app['request']->getBaseUrl());
+    // If we have an invalid IP, pop in localhost
+    $app['clientIp'] = filter_var(
+        $app['request']->getClientIp(),
+        FILTER_VALIDATE_IP,
+        FILTER_FLAG_IPV4
+    ) ?: '127.0.0.1';
 });
 
 // root route
@@ -95,7 +101,7 @@ $app->post('/gateways/{name}/authorize', function($name) use ($app) {
     $app['session']->set($sessionVar.'.card', $card);
 
     $params['card'] = $card;
-    $params['clientIp'] = $app['request']->getClientIp();
+    $params['clientIp'] = $app['clientIp'];
     $response = $gateway->authorize($params)->send();
 
     return $app['twig']->render('response.twig', array(
@@ -146,7 +152,7 @@ $app->post('/gateways/{name}/capture', function($name) use ($app) {
     // save POST data into session
     $app['session']->set($sessionVar.'.capture', $params);
 
-    $params['clientIp'] = $app['request']->getClientIp();
+    $params['clientIp'] = $app['clientIp'];
     $response = $gateway->capture($params)->send();
 
     return $app['twig']->render('response.twig', array(
@@ -189,7 +195,7 @@ $app->post('/gateways/{name}/purchase', function($name) use ($app) {
     $app['session']->set($sessionVar.'.card', $card);
 
     $params['card'] = $card;
-    $params['clientIp'] = $app['request']->getClientIp();
+    $params['clientIp'] = $app['clientIp'];
     $response = $gateway->purchase($params)->send();
 
     return $app['twig']->render('response.twig', array(
@@ -208,7 +214,7 @@ $app->match('/gateways/{name}/completePurchase', function($name) use ($app) {
     // load request data from session
     $params = $app['session']->get($sessionVar.'.purchase', array());
 
-    $params['clientIp'] = $app['request']->getClientIp();
+    $params['clientIp'] = $app['clientIp'];
     $response = $gateway->completePurchase($params)->send();
 
     return $app['twig']->render('response.twig', array(
@@ -249,7 +255,7 @@ $app->post('/gateways/{name}/create-card', function($name) use ($app) {
     $app['session']->set($sessionVar.'.card', $card);
 
     $params['card'] = $card;
-    $params['clientIp'] = $app['request']->getClientIp();
+    $params['clientIp'] = $app['clientIp'];
     $response = $gateway->createCard($params)->send();
 
     return $app['twig']->render('response.twig', array(
@@ -290,7 +296,7 @@ $app->post('/gateways/{name}/update-card', function($name) use ($app) {
     $app['session']->set($sessionVar.'.card', $card);
 
     $params['card'] = $card;
-    $params['clientIp'] = $app['request']->getClientIp();
+    $params['clientIp'] = $app['clientIp'];
     $response = $gateway->updateCard($params)->send();
 
     return $app['twig']->render('response.twig', array(
@@ -326,7 +332,7 @@ $app->post('/gateways/{name}/delete-card', function($name) use ($app) {
     // save POST data into session
     $app['session']->set($sessionVar.'.delete', $params);
 
-    $params['clientIp'] = $app['request']->getClientIp();
+    $params['clientIp'] = $app['clientIp'];
     $response = $gateway->deleteCard($params)->send();
 
     return $app['twig']->render('response.twig', array(


### PR DESCRIPTION
SagePay (and maybe some other gateways too) require a client IP address to be both present and valid IPv4.

This means that a naive install of the example application can easily cause failures for every request with the SagePay Direct gateway when using `php -S` with IPv6 configured.

I couldn't find the `isValidPublicIP` method mentioned by @judgej in #9 so I have used `filter_var` to check it is valid IPv4 and replaced with `127.0.01` if not. This is obviously not a good solution in a production environment, but in the interests of making the example application as easy to use as possible seems a fair compromise to me.

I will also raise a ticket with SagePay to encourage them to add IPv6 support.

Apologies for the pollution of the diff with PSR-2 fixes. Look only at 451683b84c03131733e54be28f8a544c57ec1834 to see the meat of the change.
